### PR TITLE
Remove checkout of MOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ To install the latest versions of [JuMP](https://github.com/JuliaOpt/JuMP.jl), [
 Pkg.update()
 Pkg.add("JuMP")
 Pkg.checkout("JuMP")
-Pkg.add("MathOptInterface")
-Pkg.checkout("MathOptInterface")
 Pkg.add("GLPK")
-Pkg.checkout("GLPK")
-
 ```
 
 To test that your installation is working, run the following code (the first time you run the code you may see the message like "INFO: Precompiling stale cache ..." for a few seconds):


### PR DESCRIPTION
JuMP is not guaranteed to work with MOI but it is guaranteed to work with the version in its REQUIRE file (so doing `Pkg.checkout("JuMP")` should be enough.
The latest release of GLPK also works with MOI so no need to checkout.