### PR TITLE
Bridges can be used in Direct mode

### DIFF
--- a/MOI_Slides.ipynb
+++ b/MOI_Slides.ipynb
@@ -934,13 +934,15 @@
    "source": [
     "Direct connection to a solver. All data is stored with solver, MOI does not save or cache anything.\n",
     "* Pros: Access to complete solver interfase (e.g. callbacks). Allowed modifications are as efficient as possible for the solver. \n",
-    "* Cons: Cannot apply incremental modifications not supported by the solver. Cannot copy the mode. Cannot use [Constraint Bridges](#Constraint-Bridges)"
+    "* Cons: Cannot apply incremental modifications not supported by the solver. Cannot copy the model. [Constraint Bridges](#Constraint-Bridges) are not enabled by default."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "model = JuMP.direct_model(GLPK.GLPKOptimizerLP(msg_lev = 0))\n",


### PR DESCRIPTION
If you do
```julia
JuMP.direct_model(MOI.Bridges.fullbridgeoptimizer(optimizer, Float64))
```
you will have automatic bridging just in Direct mode just like in automatic mode.
The only thing special done in Automatic mode with bridges is that `MOI.Bridges.fullbridgeoptimizer` is called automatically