### PR TITLE
Reformulate caching optimizer notes

### DIFF
--- a/MOI_Slides.ipynb
+++ b/MOI_Slides.ipynb
@@ -871,9 +871,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`CachingOptimizer` re-builds model when incremental modifications are not valid.\n",
-    "* Pros: No need to worry about what modifications are valid.\n",
-    "* Cons: No information about efficiency of modifications (may be re-creating the whole model for each modification)\n",
+    "`CachingOptimizer` re-builds model when incremental modifications are not supported.\n",
+    "* Pros: No need to worry about what modifications are supported.\n",
+    "* Cons: No information about efficiency of modifications (may be re-creating the whole model at each `optimize` call)\n",
     "\n",
     "**Note:** Automatic mode also provides automatic constraint transformations. See [Constraint Bridges](#Constraint-Bridges)"
    ]


### PR DESCRIPTION
"valid" is confusing. An invalid modification could be a modification using invalid indices.
More importantly, the model wil never be re-created at each modification, that would be horrible.
At the first unsupported modification, the optimizer model is dropped and further modification and only applied to the cache.
Once optimize is called, the model is copied optimizer model and then a new unsupported modification can make it be dropped again.
So the worst case is: one copy per optimize